### PR TITLE
[BUG] Route53 Incorrect domain returned

### DIFF
--- a/pkg/cloud/awscloud/aws_provider.go
+++ b/pkg/cloud/awscloud/aws_provider.go
@@ -121,6 +121,8 @@ func (a *AWSProvider) recordSetForUpdate(domain string, addressesToAdd []string)
 		return nil, nil
 	}
 
+	log.Debugf("looking up route53 record for %s", domain)
+
 	input := &route53.ListResourceRecordSetsInput{
 		HostedZoneId:    aws.String(a.cfg.HostedZoneId),
 		StartRecordName: aws.String(domain),
@@ -132,6 +134,8 @@ func (a *AWSProvider) recordSetForUpdate(domain string, addressesToAdd []string)
 	if err != nil {
 		return nil, fmt.Errorf("unable to locate resource records for domain %s: %s", domain, err)
 	}
+
+	log.Debugf("found record set for %s: %v", domain, resp.ResourceRecordSets)
 
 	var recordSet *route53.ResourceRecordSet
 

--- a/pkg/cloud/awscloud/aws_provider.go
+++ b/pkg/cloud/awscloud/aws_provider.go
@@ -139,7 +139,7 @@ func (a *AWSProvider) recordSetForUpdate(domain string, addressesToAdd []string)
 
 	var recordSet *route53.ResourceRecordSet
 
-	if len(resp.ResourceRecordSets) == 0 || aws.StringValue(resp.ResourceRecordSets[0].Name) == domain+"." {
+	if len(resp.ResourceRecordSets) == 0 || aws.StringValue(resp.ResourceRecordSets[0].Name) != domain+"." {
 		recordSet = &route53.ResourceRecordSet{
 			Name:            aws.String(domain),
 			Type:            aws.String(a.cfg.Type),

--- a/pkg/cloud/awscloud/aws_provider.go
+++ b/pkg/cloud/awscloud/aws_provider.go
@@ -139,7 +139,7 @@ func (a *AWSProvider) recordSetForUpdate(domain string, addressesToAdd []string)
 
 	var recordSet *route53.ResourceRecordSet
 
-	if len(resp.ResourceRecordSets) == 0 {
+	if len(resp.ResourceRecordSets) == 0 || aws.StringValue(resp.ResourceRecordSets[0].Name) == domain+"." {
 		recordSet = &route53.ResourceRecordSet{
 			Name:            aws.String(domain),
 			Type:            aws.String(a.cfg.Type),

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -159,7 +159,7 @@ func TestServiceCache_lookupService(t *testing.T) {
 		},
 		"returns domain from cache if already set": {
 			nil, // will result in an error if value is not in cache
-			map[string]*serviceData{"foo:bar": &serviceData{domains: []string{"foobar.example.com"}}},
+			map[string]*serviceData{"foo:bar": {domains: []string{"foobar.example.com"}}},
 			&namespaceNameKey{name: "foo", namespace: "bar"},
 			[]string{"foobar.example.com"},
 			nil,


### PR DESCRIPTION
Route53 API returns the closest match for a recordset if one doesn't exist. This causes inconsistencies & fundamentally errors.

Bug fix now checks that the returned record name matches the desired